### PR TITLE
Fix UnboundLocalError when a depth index has no contours file

### DIFF
--- a/src/depot/maps.py
+++ b/src/depot/maps.py
@@ -1837,13 +1837,23 @@ class MapGen:
         self.ocean_foundations_geojson = os.path.join(self.city_dir, "ocean_foundations.geojson")
         self.ocean_foundations_mbtiles = os.path.join(self.city_dir, "ocean_foundations.mbtiles")
         if self.bathy_data is None:
-                self.load_bathymetry_data()
+            self.load_bathymetry_data()
         if os.path.exists(self.fdepths_contours):
             with gzip.open(self.fdepths_contours, "rt", encoding="utf-8") as f:
                 depth_contours = json.load(f)
                 if self.verb:
                     print("Loaded previously processed bathymetry data")
-        
+        else:
+            # A depth index written before the contours file was introduced is
+            # reused without one, so fall back to the index itself. It carries
+            # the same contours clipped to the grid cells, which tippecanoe
+            # renders into equivalent tiles. Pass reprocess_bathymetry_data=True
+            # to rebuild both files from the source bathymetry instead.
+            depth_contours = self.bathy_data
+            if self.verb:
+                print(f"{os.path.basename(self.fdepths_contours)} not found; "
+                      "using the cell-clipped contours from the depth index")
+
         # Process bathymetry data into geojson format
         bathy_geojson_data = {'type' : 'FeatureCollection', 'features' : []}
         for f in depth_contours['depths']:

--- a/tests/mapgen.py
+++ b/tests/mapgen.py
@@ -1,4 +1,6 @@
 import sys, os
+import json
+import tempfile
 import unittest
 from unittest.mock import patch
 import numpy as np
@@ -392,6 +394,27 @@ class TestMapGen(unittest.TestCase):
         mg = MapGen("TEST", [-118.5, 33.9, -118.4, 34.0],
                     osmpbf="dummy.osm.pbf", verb=False)
         mock_makedirs.assert_called()
+
+    ##### ocean depth tile tests #####
+
+    def test_ocean_depth_tiles_without_contours_file(self):
+        """Fall back to the depth index when no contours file sits next to it."""
+        with tempfile.TemporaryDirectory() as outputdir:
+            with patch('os.path.exists'):
+                mg = MapGen("TEST", [-118.5, 33.9, -118.4, 34.0], outputdir=outputdir,
+                            osmpbf="dummy.osm.pbf", verb=False)
+            mg.fdepths_contours = os.path.join(mg.city_dir,
+                                               "ocean_depth_index_contours.json.gz")
+            mg.bathy_data = {"depths": [{"b": [0, 0, 1, 1], "d": -5,
+                                         "p": [[[0, 0], [1, 0], [1, 1], [0, 0]]]}]}
+            os.makedirs(mg.city_dir, exist_ok=True)
+            with patch.object(MapGen, "_run_command"):
+                mg._generate_ocean_depth_tiles()
+            with open(mg.ocean_foundations_geojson) as f:
+                features = json.load(f)["features"]
+
+        self.assertEqual(len(features), 1)
+        self.assertEqual(features[0]["properties"]["depth_min"], -5)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Problem

`_generate_ocean_depth_tiles` reads the depth contours from `ocean_depth_index_contours.json.gz`, but `load_bathymetry_data` only writes that file when it reprocesses the source bathymetry. When an existing `ocean_depth_index.json.gz` is found, it returns early, so the contours file is never created.

Any map whose depth index predates that file therefore reaches the loop with `depth_contours` unassigned:

```
File "src/depot/maps.py", line 1849, in _generate_ocean_depth_tiles
    for f in depth_contours['depths']:
UnboundLocalError: cannot access local variable 'depth_contours' where it is not associated with a value
```

This happens on the ordinary upgrade path: keep the generated data, rerun `generate_pmtiles` with `create_ocean_foundations=True`. The workaround is to delete the depth index or pass `reprocess_bathymetry_data=True`, which discards a cached result that is otherwise still valid.

### Change

Fall back to the depth index when no contours file sits next to it. The index holds the same contours clipped to the grid cells, so tippecanoe produces equivalent tiles from either source, and reprocessing stays available for callers who want the contours file rebuilt.

Adds a regression test covering that path; the existing suite passes.