### PR TITLE
Read and write consolidate_pops data through self

### DIFF
--- a/src/depot/demand.py
+++ b/src/depot/demand.py
@@ -652,8 +652,8 @@ class DemandData(dict):
             f"Received:\nconsolidate_max_size = {consolidate_max_size}\n" + \
             f"consolidate_distance = {consolidate_distance}"
             
-        points = demand['points']
-        pops = demand['pops']
+        points = self['points']
+        pops = self['pops']
         
         # ID to Index mapping
         pt_ids = [p['id'] for p in points]
@@ -826,10 +826,10 @@ class DemandData(dict):
                 points[pop_res_idx[i]]['popIds'].append(pop_obj['id'])
                 points[pop_job_idx[i]]['popIds'].append(pop_obj['id'])
                 
-        demand['pops'] = final_pops
+        self['pops'] = final_pops
         
         # Update points
-        demand['points'] = [p for p in demand['points'] if len(p['popIds']) > 0]
+        self['points'] = [p for p in self['points'] if len(p['popIds']) > 0]
              
         # Ensure consistent points data
         self.update(self.sanitize(self))

--- a/tests/demanddata.py
+++ b/tests/demanddata.py
@@ -249,5 +249,23 @@ class TestDemandData(unittest.TestCase):
         assert np.sum([p.startswith('test') for p in obj['points'][1]['popIds']]) == \
                np.ceil(big_pop_size/max_pop_size)
 
+    ### Consolidation ###
+
+    def test_consolidate_pops_runs(self):
+        """ Consolidation merges small pops and keeps the data consistent """
+        obj = DemandData('test_demand_data.json', 'TEST', verb=False)
+        pops_before = len(obj['pops'])
+        size_before = np.sum([p['size'] for p in obj['pops']])
+
+        obj.consolidate_pops(consolidate_max_size=50, consolidate_distance=2000)
+
+        # Merging only ever removes pops, and moves their size onto the survivor
+        assert len(obj['pops']) <= pops_before
+        assert np.sum([p['size'] for p in obj['pops']]) == size_before
+        # Every remaining pop still points at a point that exists
+        point_ids = {p['id'] for p in obj['points']}
+        assert all(p['residenceId'] in point_ids and p['jobId'] in point_ids
+                   for p in obj['pops'])
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Follow-up to the second item in #46.

`DemandData.consolidate_pops` reads and writes a free variable `demand`, which does not appear to be defined in the method's scope (`demand.py:655-656` and `829-832`), so a call raises `NameError` before doing any work:

```
points = demand['points']
        ^^^^^^
NameError: name 'demand' is not defined
```

Since `DemandData` subclasses `dict` and the surrounding methods all operate on `self`, this switches those four references over. If you had something else in mind there, happy to redo it.

The regression test calls the method on the bundled fixture. It fails with the `NameError` before the change; after it, consolidation takes the fixture from 9 pops to 7 and the test checks the invariants that merging should hold: pops only ever go away, the total population is unchanged, and every surviving pop still references a point that exists.

---

*Written in Portuguese and translated into English with help from Claude.*